### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -4,6 +4,8 @@
 name: Test and coverage
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/neo-f/soda/security/code-scanning/1](https://github.com/neo-f/soda/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and uploads coverage data to Codecov, it only needs `contents: read` permissions. Adding this block at the root level ensures that all jobs in the workflow inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
